### PR TITLE
feat(ui): add SwiftUIIntrospect and improve window layout

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,10 +1,10 @@
 {
   "indentation" : {
-    "spaces" : 2
+    "spaces" : 4
   },
   "lineLength" : 120,
   "maximumBlankLines" : 1,
   "respectsExistingLineBreaks" : true,
-  "tabWidth" : 2,
+  "tabWidth" : 4,
   "version" : 1
 }

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,1 +1,1 @@
---indent 2
+--indent 4

--- a/ABPlayer/Sources/ABPlayerApp.swift
+++ b/ABPlayer/Sources/ABPlayerApp.swift
@@ -6,6 +6,7 @@ struct ABPlayerApp: App {
         WindowGroup {
             MainSplitView()
         }
+        .defaultSize(width: 1200, height: 800)
         .windowToolbarStyle(.unified(showsTitle: true))
 #if DEBUG
         .commands {

--- a/ABPlayer/Sources/Views/ContentView.swift
+++ b/ABPlayer/Sources/Views/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     let selectedMenu: MenuItem
-    
+
     var body: some View {
         Text(selectedMenu.rawValue)
             .font(.largeTitle)

--- a/ABPlayer/Sources/Views/MainSplitView.swift
+++ b/ABPlayer/Sources/Views/MainSplitView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import SwiftUI
+import SwiftUIIntrospect
 
 struct MainSplitView: View {
     @State private var selectedMenu: MenuItem = .todaysPicks
@@ -7,13 +9,13 @@ struct MainSplitView: View {
         MenuSection(title: "Discover", items: [.todaysPicks, .podcast]),
         MenuSection(title: "My Listening", items: [.downloads, .history, .myUploads, .myResources, .vocabulary]),
         MenuSection(title: "Favorites", items: [.favorites]),
-        MenuSection(title: "Playlists", items: [.liked])
+        MenuSection(title: "Playlists", items: [.liked]),
     ]
-    
+
     var body: some View {
         NavigationSplitView(columnVisibility: .constant(.doubleColumn)) {
             SidebarView(selectedMenu: $selectedMenu, menuSections: menuSections)
-                .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 280)
+                .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
                 .toolbar(removing: .sidebarToggle)
                 .toolbar {
                     Text("")
@@ -21,6 +23,13 @@ struct MainSplitView: View {
         } detail: {
             ContentView(selectedMenu: selectedMenu)
         }
+        .introspect(.navigationSplitView, on: .macOS(.v26), customize: { nsSplitView in
+            guard let controller = nsSplitView.delegate as? NSSplitViewController else {
+                return
+            }
+            controller.splitViewItems.first?.canCollapse = false
+        })
+        .frame(minWidth: 960, minHeight: 640)
         .navigationSplitViewStyle(.balanced)
         .navigationTitle(selectedMenu.id)
         .toolbarBackground(.hidden, for: .windowToolbar)

--- a/ABPlayer/Sources/Views/SidebarView.swift
+++ b/ABPlayer/Sources/Views/SidebarView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SidebarView: View {
     @Binding var selectedMenu: MenuItem
     let menuSections: [MenuSection]
-    
+
     var body: some View {
         List {
             ForEach(menuSections) { section in
@@ -17,13 +17,13 @@ struct SidebarView: View {
                         .padding(.horizontal, 8)
                         .listItemTint(
                             selectedMenu == item
-                            ? Color.accentColor
-                            : Color(.primary)
+                                ? Color.accentColor
+                                : Color(.primary)
                         )
                         .background(
                             selectedMenu == item
-                            ? Color(.listRowBackground)
-                            : Color.clear
+                                ? Color(.listRowBackground)
+                                : Color.clear
                         )
                         .foregroundStyle(
                             selectedMenu == item ? Color.accentColor : Color(.primary)
@@ -49,7 +49,7 @@ struct SidebarView: View {
             MenuSection(title: "Discover", items: [.todaysPicks, .podcast]),
             MenuSection(title: "My Listening", items: [.downloads, .history, .myUploads, .myResources, .vocabulary]),
             MenuSection(title: "Favorites", items: [.favorites]),
-            MenuSection(title: "Playlists", items: [.liked])
+            MenuSection(title: "Playlists", items: [.liked]),
         ]
     )
 }

--- a/Project.swift
+++ b/Project.swift
@@ -40,47 +40,8 @@ let project = Project(
         .external(name: "KeyboardShortcuts"),
         .external(name: "Sparkle"),
         .external(name: "TelemetryDeck"),
+        .external(name: "SwiftUIIntrospect"),
       ]
-    ),
-    .target(
-      name: "ABPlayerDev",
-      destinations: .macOS,
-      product: .app,
-      bundleId: "cc.ihugo.app.ABPlayerDev",
-      deploymentTargets: .macOS("26.0"),
-      infoPlist: .extendingDefault(with: [
-        "CFBundleVersion": .string(buildVersionString),
-        "CFBundleShortVersionString": .string(shortVersionString),
-        "NSMainStoryboardFile": "",
-        "SUFeedURL":
-          "https://github.com/sunset-valley/ABPlayer/releases/latest/download/appcast.xml",
-        "SUEnableAutomaticChecks": true,
-        "SUPublicEDKey": "Zw9DuoU9cuGJGt81eRRfWq5OwhCG+udkeOBwScjchU0=",
-      ]),
-      buildableFolders: [
-        "ABPlayer/Sources",
-        "ABPlayer/Resources",
-      ],
-      dependencies: [
-        .sdk(name: "AppIntents", type: .framework, status: .optional),
-        .external(name: "Sentry"),
-        .external(name: "WhisperKit"),
-        .external(name: "KeyboardShortcuts"),
-        .external(name: "Sparkle"),
-        .external(name: "TelemetryDeck"),
-      ]
-    ),
-    .target(
-      name: "ABPlayerTests",
-      destinations: .macOS,
-      product: .unitTests,
-      bundleId: "cc.ihugo.app.ABPlayerTests",
-      deploymentTargets: .macOS("26.0"),
-      infoPlist: .default,
-      buildableFolders: [
-        "ABPlayer/Tests",
-      ],
-      dependencies: [.target(name: "ABPlayer")]
     ),
   ]
 )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c4d78fb62952120c0faefabd9d9243d6b10a2e3f7b2e37c6cc31e8851c14ef3d",
+  "originHash" : "f50ce1cddef3a74af92f2c9db44a8c0fbdab0ae071eb5502795e15b6d7dd1b54",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -71,6 +71,15 @@
       "state" : {
         "revision" : "8f332c1c256ba26cc46f74c9e5af94f7b1c37a9c",
         "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swiftui-introspect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/siteline/swiftui-introspect",
+      "state" : {
+        "revision" : "a08b87f96b41055577721a6e397562b21ad52454",
+        "version" : "26.0.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -14,6 +14,7 @@ import PackageDescription
       "KeyboardShortcuts-Dynamic": .framework,
       "Sparkle-Dynamic": .framework,
       "TelemetryDeck-Dynamic": .framework,
+      "SwiftUIIntrospect-Dynamic": .framework,
     ]
   )
 #endif
@@ -29,5 +30,6 @@ let package = Package(
     .package(url: "https://github.com/iHugo-Tang/KeyboardShortcuts", branch: "main"),
     .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
     .package(url: "https://github.com/TelemetryDeck/SwiftSDK", from: "2.11.0"),
+    .package(url: "https://github.com/siteline/swiftui-introspect", from: "26.0.0"),
   ]
 )


### PR DESCRIPTION
- Add SwiftUIIntrospect dependency for AppKit integration
- Set default window size to 1200x800
- Add minimum window size constraints (960x640)
- Prevent sidebar collapse in NavigationSplitView
- Update indentation from 2 to 4 spaces in swift-format config
- Remove ABPlayerDev target and ABPlayerTests from Project.swift
- Adjust sidebar width (min: 200, ideal: 220)